### PR TITLE
Fix AirControl bug

### DIFF
--- a/Quake3Movement/Scripts/Q3PlayerController.cs
+++ b/Quake3Movement/Scripts/Q3PlayerController.cs
@@ -182,9 +182,8 @@ namespace Q3Movement
             // Change direction while slowing down.
             if (dot > 0)
             {
-                m_PlayerVelocity.x *= speed + targetDir.x * k;
-                m_PlayerVelocity.y *= speed + targetDir.y * k;
-                m_PlayerVelocity.z *= speed + targetDir.z * k;
+                m_PlayerVelocity.x = m_PlayerVelocity.x * speed + targetDir.x * k;
+                m_PlayerVelocity.z = m_PlayerVelocity.z * speed + targetDir.z * k;
 
                 m_PlayerVelocity.Normalize();
                 m_MoveDirectionNorm = m_PlayerVelocity;


### PR DESCRIPTION
When jumping and holding forward (Space + W) the players velocity was increasing to the left/right depending on the angle they were facing.